### PR TITLE
Test that the store module finds the different store descriptors

### DIFF
--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreDescriptorTest.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreDescriptorTest.java
@@ -1,12 +1,32 @@
 package se.tre.freki.storage.cassandra;
 
+import se.tre.freki.storage.StoreDescriptor;
 import se.tre.freki.storage.StoreDescriptorTest;
+import se.tre.freki.storage.StoreModule;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
 
 public class CassandraStoreDescriptorTest extends StoreDescriptorTest {
   @Before
   public void setUp() throws Exception {
     storeDescriptor = new CassandraStoreDescriptor();
+  }
+
+  @Test
+  public void testStoreModuleFindsCassandraStore() {
+    final StoreModule storeModule = new StoreModule();
+    final Iterable<StoreDescriptor> storeDescriptors = storeModule.provideStoreDescriptors();
+
+    Iterables.find(storeDescriptors, new Predicate<StoreDescriptor>() {
+      @Override
+      public boolean apply(@Nullable final StoreDescriptor storeDescriptor) {
+        return storeDescriptor instanceof CassandraStoreDescriptor;
+      }
+    });
   }
 }

--- a/core/src/main/java/se/tre/freki/storage/StoreModule.java
+++ b/core/src/main/java/se/tre/freki/storage/StoreModule.java
@@ -54,7 +54,7 @@ public class StoreModule {
    * as services and thus are found by the {@link java.util.ServiceLoader}
    */
   @Provides
-  Iterable<StoreDescriptor> provideStoreDescriptors() {
+  public Iterable<StoreDescriptor> provideStoreDescriptors() {
     return ServiceLoader.load(StoreDescriptor.class);
   }
 }

--- a/core/src/test/java/se/tre/freki/storage/StoreModuleTest.java
+++ b/core/src/test/java/se/tre/freki/storage/StoreModuleTest.java
@@ -1,6 +1,5 @@
 package se.tre.freki.storage;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -9,6 +8,7 @@ import se.tre.freki.labels.LabelId;
 import se.tre.freki.utils.InvalidConfigException;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.typesafe.config.Config;
@@ -17,18 +17,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 public class StoreModuleTest {
-  /**
-   * A constant that describes the number of stores that the core project comes with and thus how
-   * many store descriptors that the {@link java.util .ServiceLoader} should be able to find.
-   *
-   * <p>The only store provided by the core project is the {@link MemoryStore} which explains the
-   * number the one.
-   */
-  private static final int NUM_STORES = 1;
-
   @Inject Config config;
 
   private Iterable<StoreDescriptor> storeDescriptors;
@@ -66,9 +58,14 @@ public class StoreModuleTest {
   }
 
   @Test
-  public void testNumberOfFoundStoreDescriptors() {
+  public void testFindsMemoryStore() {
     Iterable<StoreDescriptor> storeDescriptors = supplier.provideStoreDescriptors();
-    assertEquals(NUM_STORES, Iterables.size(storeDescriptors));
+    Iterables.find(storeDescriptors, new Predicate<StoreDescriptor>() {
+      @Override
+      public boolean apply(@Nullable final StoreDescriptor input) {
+        return input instanceof MemoryStoreDescriptor;
+      }
+    });
   }
 
   private static class TestStoreDescriptor extends StoreDescriptor {


### PR DESCRIPTION
This changes the tests for the store module and store descriptors so that the store module tests and store descriptor tests checks that the store module can find specific implementations of the store descriptors instead of relying of maintaining a manual count we check against. It is also more reliable since the count varies depending on the class path used to run the tests.