### PR TITLE
Add a findbugs filter to ignore warnings in generated and safe code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,10 @@ subprojects {
         source = fileTree(dir: "src/test", include: "**/*.java")
     }
 
+    findbugs {
+        excludeFilter = file("$rootDir/findbugs_filter.xml")
+    }
+
     // Configure intellij to add the generated sources folders to its build path
     idea {
         module {

--- a/findbugs_filter.xml
+++ b/findbugs_filter.xml
@@ -1,0 +1,12 @@
+<FindBugsFilter>
+  <Match>
+    <Class name="se.tre.freki.utils.KillingUncaughtHandler" />
+    <Method name="uncaughtException" />
+    <Bug pattern="DM_EXIT" />
+  </Match>
+
+  <Match>
+    <Package name="se.tre.freki.grpc" />
+    <Bug pattern="UCF_USELESS_CONTROL_FLOW" />
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
This solves the Findbugs warnings about `system.exit` and about useless flow control in the generated protocol buffers code. Together with #35 it fixes all of the problems in #32.