### PR TITLE
Let the main thread die in HttpServer instead of just waiting around

### DIFF
--- a/core/src/main/java/se/tre/freki/utils/EventLoopGroups.java
+++ b/core/src/main/java/se/tre/freki/utils/EventLoopGroups.java
@@ -55,7 +55,7 @@ public class EventLoopGroups {
    */
   private static EventLoopGroup newLoopGroup(final String baseName, final int parallelism) {
     workerGroup = new EpollEventLoopGroup(parallelism, threadFactory(baseName));
-    Runtime.getRuntime().addShutdownHook(shutdownHookFor(workerGroup));
+    Runtime.getRuntime().addShutdownHook(shutdownHookFor(workerGroup, baseName));
     return workerGroup;
   }
 
@@ -80,14 +80,15 @@ public class EventLoopGroups {
    * @param eventLoopGroup The event loop group to shutdown
    * @return A new not started thread that will shutdown the provided event loop group when started
    */
-  private static Thread shutdownHookFor(final EventLoopGroup eventLoopGroup) {
-    return new Thread(new EventLoopGroupShutdownHook(eventLoopGroup));
+  private static Thread shutdownHookFor(final EventLoopGroup eventLoopGroup,
+                                        final String baseName) {
+    return new Thread(null, new EventLoopGroupShutdownHook(eventLoopGroup), baseName + "-shutdown");
   }
 
   /**
    * A runnable class that will shutdown {@link EventLoopGroup}s when ran.
    *
-   * @see #shutdownHookFor(EventLoopGroup)
+   * @see #shutdownHookFor(EventLoopGroup, String)
    */
   private static class EventLoopGroupShutdownHook implements Runnable {
     private final EventLoopGroup eventLoopGroup;

--- a/core/src/main/java/se/tre/freki/utils/EventLoopGroups.java
+++ b/core/src/main/java/se/tre/freki/utils/EventLoopGroups.java
@@ -3,10 +3,14 @@ package se.tre.freki.utils;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ThreadFactory;
 
 public class EventLoopGroups {
+  private static final Logger LOG = LoggerFactory.getLogger(EventLoopGroups.class);
+
   private static EventLoopGroup bossGroup;
   private static EventLoopGroup workerGroup;
 
@@ -54,8 +58,10 @@ public class EventLoopGroups {
    * @return An initialized event loop group who will be shutdown by a shutdown hook
    */
   private static EventLoopGroup newLoopGroup(final String baseName, final int parallelism) {
-    workerGroup = new EpollEventLoopGroup(parallelism, threadFactory(baseName));
+    EventLoopGroup workerGroup = new EpollEventLoopGroup(parallelism, threadFactory(baseName));
     Runtime.getRuntime().addShutdownHook(shutdownHookFor(workerGroup, baseName));
+    LOG.info("Created event loop group with base name {} and parallelism {}",
+        baseName, parallelism);
     return workerGroup;
   }
 

--- a/core/src/main/java/se/tre/freki/utils/EventLoopGroups.java
+++ b/core/src/main/java/se/tre/freki/utils/EventLoopGroups.java
@@ -109,7 +109,7 @@ public class EventLoopGroups {
         eventLoopGroup.shutdownGracefully().sync();
       } catch (InterruptedException e) {
         // We can not use the logging framework since it may either be in the process of shutting
-        // down or it may already have done so. This will print to stderr with is good enough.
+        // down or it may already have done so. This will print to stderr which is good enough.
         e.printStackTrace();
       }
     }


### PR DESCRIPTION
This PR changes the behavior in HttpServer to let the main thread die instead of just blocking until the Netty server shutsdown.

It also adds some logging so there parallelism levels of the different event loop groups are more visible.