### PR TITLE
Extract the cassandra base time construction into a utility class

### DIFF
--- a/cassandra/src/main/java/se/tre/freki/storage/cassandra/BaseTimes.java
+++ b/cassandra/src/main/java/se/tre/freki/storage/cassandra/BaseTimes.java
@@ -1,0 +1,16 @@
+package se.tre.freki.storage.cassandra;
+
+/**
+ * Utility class for working with the base times as used in the Cassandra store.
+ */
+final class BaseTimes {
+  private BaseTimes() {
+  }
+
+  /**
+   * Calculate the base time based on a timestamp to be used in a partition key.
+   */
+  static long baseTimeFor(final long timestamp) {
+    return (timestamp - (timestamp % CassandraConst.BASE_TIME_PERIOD));
+  }
+}

--- a/cassandra/src/main/java/se/tre/freki/storage/cassandra/CassandraStore.java
+++ b/cassandra/src/main/java/se/tre/freki/storage/cassandra/CassandraStore.java
@@ -118,13 +118,6 @@ public class CassandraStore extends Store {
   }
 
   /**
-   * Calculate the base time based on a timestamp to be used in a row key.
-   */
-  static long buildBaseTime(final long timestamp) {
-    return (timestamp - (timestamp % CassandraConst.BASE_TIME_PERIOD));
-  }
-
-  /**
    * In this method we prepare all the statements used for accessing Cassandra.
    */
   private void prepareStatements() {
@@ -240,7 +233,7 @@ public class CassandraStore extends Store {
 
     final ByteBuffer tsid = ByteBuffer.wrap(tsidHasher.hash().asBytes());
 
-    final long baseTime = buildBaseTime(timestamp);
+    final long baseTime = BaseTimes.baseTimeFor(timestamp);
 
     addPointStatement.setBytesUnsafe(AddPointStatementMarkers.ID.ordinal(), tsid);
     addPointStatement.setLong(AddPointStatementMarkers.BASE_TIME.ordinal(), baseTime);

--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/BaseTimesTest.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/BaseTimesTest.java
@@ -1,0 +1,14 @@
+package se.tre.freki.storage.cassandra;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class BaseTimesTest {
+  @Test
+  public void testBuildBaseTimeNormalizes() {
+    final long timestamp = 1434545416154L;
+    final long baseTime = 1434542400000L;
+    assertEquals(baseTime, BaseTimes.baseTimeFor(timestamp));
+  }
+}

--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreTest.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreTest.java
@@ -81,13 +81,6 @@ public class CassandraStoreTest extends StoreTest<CassandraStore> {
   }
 
   @Test
-  public void testBuildBaseTimeNormalizes() {
-    final long timestamp = 1434545416154L;
-    final long baseTime = 1434542400000L;
-    assertEquals(baseTime, CassandraStore.buildBaseTime(timestamp));
-  }
-
-  @Test
   public void testCreateId() throws Exception {
     final String doesNotExistName = "does.not.exist";
     final long doesNotExistId = 10L;


### PR DESCRIPTION
It's likely we'll need to add more base time utility methods when we work the the query related functionality. Extracting this now will likely prevent some merge conflicts and the query branches from straying too far from master.