### PR TITLE
Register metrics optionally

### DIFF
--- a/cassandra/src/main/java/se/tre/freki/storage/cassandra/CassandraStore.java
+++ b/cassandra/src/main/java/se/tre/freki/storage/cassandra/CassandraStore.java
@@ -33,6 +33,7 @@ import se.tre.freki.storage.cassandra.statements.AddPointStatements.AddPointStat
 import se.tre.freki.storage.cassandra.statements.FetchPointsStatements;
 import se.tre.freki.storage.cassandra.statements.FetchPointsStatements.SelectPointStatementMarkers;
 
+import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
@@ -302,6 +303,11 @@ public class CassandraStore extends Store {
         return createId(id, name, type);
       }
     });
+  }
+
+  @Override
+  public void registerMetricsWith(final MetricRegistry registry) {
+    registry.registerAll(cluster.getMetrics().getRegistry());
   }
 
   @Nonnull

--- a/cassandra/src/main/java/se/tre/freki/storage/cassandra/CassandraStoreDescriptor.java
+++ b/cassandra/src/main/java/se/tre/freki/storage/cassandra/CassandraStoreDescriptor.java
@@ -4,7 +4,6 @@ import se.tre.freki.labels.LabelId;
 import se.tre.freki.storage.StoreDescriptor;
 import se.tre.freki.utils.InvalidConfigException;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Session;
@@ -68,12 +67,10 @@ public class CassandraStoreDescriptor extends StoreDescriptor {
   }
 
   @Override
-  public CassandraStore createStore(final Config config,
-                                    final MetricRegistry metrics) {
+  public CassandraStore createStore(final Config config) {
     final Cluster cluster = createCluster(config);
     final String keyspace = config.getString("freki.storage.cassandra.keyspace");
     final Session session = connectTo(cluster, keyspace);
-    registerMetrics(cluster, metrics);
 
     final IndexStrategy addPointIndexStrategy = indexStrategyFor(session,
         config.getBoolean("freki.storage.cassandra.index_on_add_point"));
@@ -101,13 +98,5 @@ public class CassandraStoreDescriptor extends StoreDescriptor {
     }
 
     return new IndexStrategy.NoOpIndexingStrategy();
-  }
-
-  /**
-   * Register the metrics that are exposed on the provided {@link com.datastax.driver.core.Cluster}
-   * with the provided {@link com.codahale.metrics.MetricRegistry} instance.
-   */
-  private void registerMetrics(final Cluster cluster, final MetricRegistry metrics) {
-    metrics.registerAll(cluster.getMetrics().getRegistry());
   }
 }

--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreDataPointTests.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreDataPointTests.java
@@ -12,7 +12,6 @@ import se.tre.freki.labels.StaticTimeSeriesId;
 import se.tre.freki.query.DataPoint;
 import se.tre.freki.query.DataPoint.LongDataPoint;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.ResultSet;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
@@ -46,7 +45,7 @@ public class CassandraStoreDataPointTests {
     final CassandraStoreDescriptor storeDescriptor = (CassandraStoreDescriptor)
         cassandraTestComponent.storeDescriptor();
 
-    store = storeDescriptor.createStore(config, new MetricRegistry());
+    store = storeDescriptor.createStore(config);
 
     metric1 = fromLong(1L);
     metric1 = fromLong(2L);

--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreTest.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreTest.java
@@ -10,7 +10,6 @@ import se.tre.freki.labels.LabelType;
 import se.tre.freki.storage.StoreTest;
 import se.tre.freki.storage.cassandra.IndexStrategy.NoOpIndexingStrategy;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import com.typesafe.config.Config;
@@ -40,7 +39,7 @@ public class CassandraStoreTest extends StoreTest<CassandraStore> {
     // at least fail hard if it ever is any other store.
     storeDescriptor = (CassandraStoreDescriptor) cassandraTestComponent.storeDescriptor();
 
-    return storeDescriptor.createStore(config, new MetricRegistry());
+    return storeDescriptor.createStore(config);
   }
 
   @After

--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/search/CassandraSearchPluginTest.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/search/CassandraSearchPluginTest.java
@@ -12,7 +12,6 @@ import se.tre.freki.storage.cassandra.CassandraTestComponent;
 import se.tre.freki.storage.cassandra.CassandraTestHelpers;
 import se.tre.freki.storage.cassandra.DaggerCassandraTestComponent;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
@@ -39,7 +38,7 @@ public class CassandraSearchPluginTest {
     // at least fail hard if it ever is any other store.
     storeDescriptor = (CassandraStoreDescriptor) cassandraTestComponent.storeDescriptor();
 
-    store = storeDescriptor.createStore(config, new MetricRegistry());
+    store = storeDescriptor.createStore(config);
     searchPlugin = new CassandraSearchPlugin(store);
   }
 

--- a/core/src/main/java/se/tre/freki/core/CoreModule.java
+++ b/core/src/main/java/se/tre/freki/core/CoreModule.java
@@ -1,5 +1,7 @@
 package se.tre.freki.core;
 
+import se.tre.freki.storage.Store;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
@@ -22,13 +24,20 @@ public class CoreModule {
 
   @Provides
   @Singleton
-  MetricRegistry provideMetricRegistry() {
+  MetricRegistry provideMetricRegistry(final Store store,
+                                       final LabelClient labelClient,
+                                       final DataPointsClient dataPointsClient) {
     MetricRegistry registry = new MetricRegistry();
     registry.registerAll(new ClassLoadingGaugeSet());
     registry.registerAll(new GarbageCollectorMetricSet());
     registry.registerAll(new MemoryUsageGaugeSet());
     registry.registerAll(new ThreadStatesGaugeSet());
     registry.register("descriptor-usage", new FileDescriptorRatioGauge());
+
+    store.registerMetricsWith(registry);
+    labelClient.registerMetricsWith(registry);
+    dataPointsClient.registerMetricsWith(registry);
+
     return registry;
   }
 }

--- a/core/src/main/java/se/tre/freki/stats/Measurable.java
+++ b/core/src/main/java/se/tre/freki/stats/Measurable.java
@@ -1,0 +1,16 @@
+package se.tre.freki.stats;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * An interface that marks that implementors are able to register metrics with a {@link
+ * MetricRegistry}.
+ */
+public interface Measurable {
+  /**
+   * Register the metrics the implementation has with the provided metric registry.
+   *
+   * @param registry The metric registry to register the metrics with
+   */
+  void registerMetricsWith(final MetricRegistry registry);
+}

--- a/core/src/main/java/se/tre/freki/storage/Store.java
+++ b/core/src/main/java/se/tre/freki/storage/Store.java
@@ -7,6 +7,7 @@ import se.tre.freki.meta.Annotation;
 import se.tre.freki.meta.LabelMeta;
 import se.tre.freki.query.DataPoint;
 import se.tre.freki.query.TimeSeriesQuery;
+import se.tre.freki.stats.Measurable;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -21,7 +22,7 @@ import javax.annotation.Nonnull;
  * An abstract class defining the functions any database used with Freki must implement. Another
  * requirement is that the database connection has to be asynchronous.
  */
-public abstract class Store implements Closeable {
+public abstract class Store implements Closeable, Measurable {
   //
   // Identifier management
   //

--- a/core/src/main/java/se/tre/freki/storage/StoreDescriptor.java
+++ b/core/src/main/java/se/tre/freki/storage/StoreDescriptor.java
@@ -2,13 +2,12 @@ package se.tre.freki.storage;
 
 import se.tre.freki.labels.LabelId;
 
-import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.Config;
 
 import javax.annotation.Nonnull;
 
 public abstract class StoreDescriptor {
-  public abstract Store createStore(Config config, MetricRegistry metrics);
+  public abstract Store createStore(Config config);
 
   /**
    * Get an object that is capable of serializing the {@link LabelId} implementation used by this

--- a/core/src/main/java/se/tre/freki/storage/StoreModule.java
+++ b/core/src/main/java/se/tre/freki/storage/StoreModule.java
@@ -2,7 +2,6 @@ package se.tre.freki.storage;
 
 import se.tre.freki.utils.InvalidConfigException;
 
-import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.Config;
 import dagger.Module;
 import dagger.Provides;
@@ -18,9 +17,8 @@ public class StoreModule {
   @Provides
   @Singleton
   Store provideStore(final StoreDescriptor storeDescriptor,
-                         final Config config,
-                         final MetricRegistry metrics) {
-    return storeDescriptor.createStore(config, metrics);
+                     final Config config) {
+    return storeDescriptor.createStore(config);
   }
 
   /**

--- a/core/src/test/java/se/tre/freki/labels/LabelClientTypeContextTest.java
+++ b/core/src/test/java/se/tre/freki/labels/LabelClientTypeContextTest.java
@@ -17,7 +17,6 @@ import se.tre.freki.DaggerTestComponent;
 import se.tre.freki.storage.Store;
 import se.tre.freki.utils.TestUtil;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -38,7 +37,6 @@ public final class LabelClientTypeContextTest {
   private static final long MAX_CACHE_SIZE = 2000;
 
   @Inject Store store;
-  @Inject MetricRegistry metrics;
 
   @Mock EventBus eventBus;
 
@@ -55,31 +53,25 @@ public final class LabelClientTypeContextTest {
 
   @Test(expected = NullPointerException.class)
   public void testConstructorNoStore() {
-    typeContext = new LabelClientTypeContext(null, LabelType.METRIC, metrics, eventBus,
+    typeContext = new LabelClientTypeContext(null, LabelType.METRIC, eventBus,
         MAX_CACHE_SIZE);
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructorNoType() {
-    typeContext = new LabelClientTypeContext(store, null, metrics, eventBus, MAX_CACHE_SIZE);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testConstructorNoMetrics() {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, null, eventBus,
-        MAX_CACHE_SIZE);
+    typeContext = new LabelClientTypeContext(store, null, eventBus, MAX_CACHE_SIZE);
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructorNoEventbus() {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, null,
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, null,
         MAX_CACHE_SIZE);
   }
 
 
   @Test(expected = IllegalArgumentException.class)
   public void testConstructorNegativeMaxSize() {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, eventBus, -5);
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, eventBus, -5);
   }
 
   @Test
@@ -87,7 +79,7 @@ public final class LabelClientTypeContextTest {
     store = mock(Store.class);
     final LabelId id = randomLabelId();
 
-    typeContext = new LabelClientTypeContext(store, TAGK, metrics, eventBus, MAX_CACHE_SIZE);
+    typeContext = new LabelClientTypeContext(store, TAGK, eventBus, MAX_CACHE_SIZE);
 
     when(store.getName(id, TAGK)).thenAnswer(
         new Answer<ListenableFuture<Optional<String>>>() {
@@ -110,7 +102,7 @@ public final class LabelClientTypeContextTest {
 
   @Test
   public void testGetNameAbsent() throws Exception {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, eventBus,
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, eventBus,
         MAX_CACHE_SIZE);
     assertFalse(typeContext.getName(mock(LabelId.class)).get().isPresent());
   }
@@ -120,7 +112,7 @@ public final class LabelClientTypeContextTest {
     store = mock(Store.class);
     final LabelId id = randomLabelId();
 
-    typeContext = new LabelClientTypeContext(store, TAGK, metrics, eventBus, MAX_CACHE_SIZE);
+    typeContext = new LabelClientTypeContext(store, TAGK, eventBus, MAX_CACHE_SIZE);
 
     when(store.getId("name", TAGK)).thenAnswer(
         new Answer<ListenableFuture<Optional<LabelId>>>() {
@@ -143,14 +135,14 @@ public final class LabelClientTypeContextTest {
 
   @Test
   public void testGetIdAbsent() throws Exception {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, eventBus,
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, eventBus,
         MAX_CACHE_SIZE);
     assertFalse(typeContext.getId("foo").get().isPresent());
   }
 
   @Test
   public void createIdPublishesEventOnSuccess() throws Exception {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, eventBus,
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, eventBus,
         MAX_CACHE_SIZE);
     typeContext.createId("foo").get();
     verify(eventBus).post(any(LabelCreatedEvent.class));
@@ -158,7 +150,7 @@ public final class LabelClientTypeContextTest {
 
   @Test
   public void testRenameNewNameExists() throws Exception {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, eventBus,
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, eventBus,
         MAX_CACHE_SIZE);
     typeContext.createId("newName").get();
     try {
@@ -171,7 +163,7 @@ public final class LabelClientTypeContextTest {
 
   @Test
   public void testRenameIdNotFoundOnOldName() throws Exception {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, eventBus,
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, eventBus,
         MAX_CACHE_SIZE);
     try {
       typeContext.rename("oldName", "newName").get();
@@ -184,7 +176,7 @@ public final class LabelClientTypeContextTest {
 
   @Test
   public void testRename() throws Exception {
-    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, metrics, eventBus,
+    typeContext = new LabelClientTypeContext(store, LabelType.METRIC, eventBus,
         MAX_CACHE_SIZE);
 
     final LabelId labelId = typeContext.createId("oldName").get();

--- a/core/src/test/java/se/tre/freki/labels/WildcardIdLookupStrategyTest.java
+++ b/core/src/test/java/se/tre/freki/labels/WildcardIdLookupStrategyTest.java
@@ -9,7 +9,6 @@ import se.tre.freki.DaggerTestComponent;
 import se.tre.freki.storage.Store;
 import se.tre.freki.utils.TestUtil;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.eventbus.EventBus;
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,7 +21,6 @@ import javax.inject.Inject;
 
 public class WildcardIdLookupStrategyTest {
   @Inject Store client;
-  @Inject MetricRegistry metricRegistry;
   @Inject EventBus eventBus;
 
   private LabelClientTypeContext uid;
@@ -36,8 +34,7 @@ public class WildcardIdLookupStrategyTest {
     DaggerTestComponent.create().inject(this);
 
     final long maxCacheSize = 2000;
-    uid = new LabelClientTypeContext(client, LabelType.METRIC, metricRegistry, eventBus,
-        maxCacheSize);
+    uid = new LabelClientTypeContext(client, LabelType.METRIC, eventBus, maxCacheSize);
 
     lookupStrategy = new IdLookupStrategy.WildcardIdLookupStrategy();
   }

--- a/core/src/test/java/se/tre/freki/storage/MemoryStore.java
+++ b/core/src/test/java/se/tre/freki/storage/MemoryStore.java
@@ -8,6 +8,7 @@ import se.tre.freki.meta.LabelMeta;
 import se.tre.freki.query.DataPoint;
 import se.tre.freki.query.TimeSeriesQuery;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Optional;
 import com.google.common.collect.HashBasedTable;
@@ -112,6 +113,11 @@ public class MemoryStore extends Store {
     final String qualifier = type.toString().toLowerCase() + "_meta";
     final LabelMeta meta = labelMetas.get(uid, qualifier);
     return Futures.immediateFuture(Optional.fromNullable(meta));
+  }
+
+  @Override
+  public void registerMetricsWith(final MetricRegistry registry) {
+    // These are not the metrics you are looking for.
   }
 
   @Nonnull

--- a/core/src/test/java/se/tre/freki/storage/MemoryStoreDescriptor.java
+++ b/core/src/test/java/se/tre/freki/storage/MemoryStoreDescriptor.java
@@ -2,7 +2,6 @@ package se.tre.freki.storage;
 
 import se.tre.freki.labels.LabelId;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.auto.service.AutoService;
 import com.typesafe.config.Config;
 
@@ -11,7 +10,7 @@ import javax.annotation.Nonnull;
 @AutoService(StoreDescriptor.class)
 public class MemoryStoreDescriptor extends StoreDescriptor {
   @Override
-  public Store createStore(final Config config, final MetricRegistry metrics) {
+  public Store createStore(final Config config) {
     return new MemoryStore();
   }
 

--- a/core/src/test/java/se/tre/freki/storage/StoreModuleTest.java
+++ b/core/src/test/java/se/tre/freki/storage/StoreModuleTest.java
@@ -7,7 +7,6 @@ import se.tre.freki.DaggerTestComponent;
 import se.tre.freki.labels.LabelId;
 import se.tre.freki.utils.InvalidConfigException;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -70,7 +69,7 @@ public class StoreModuleTest {
 
   private static class TestStoreDescriptor extends StoreDescriptor {
     @Override
-    public Store createStore(final Config config, final MetricRegistry metrics) {
+    public Store createStore(final Config config) {
       return mock(Store.class);
     }
 


### PR DESCRIPTION
This refactoring allows us to optionally not register metrics and thereby after #79 to not always write metrics to the database. This would be useful for small command line applications for example. It also simplifies the implementation in the same issue due to what otherwise would become cyclic dependencies.