### PR TITLE
Casssandra tests created and test with label without meta set created

### DIFF
--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreTest.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/CassandraStoreTest.java
@@ -1,19 +1,25 @@
 package se.tre.freki.storage.cassandra;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static se.tre.freki.labels.LabelType.METRIC;
 
 import se.tre.freki.labels.LabelId;
 import se.tre.freki.labels.LabelType;
+import se.tre.freki.meta.LabelMeta;
 import se.tre.freki.storage.StoreTest;
 import se.tre.freki.storage.cassandra.IndexStrategy.NoOpIndexingStrategy;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.google.common.base.Optional;
 import com.typesafe.config.Config;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -148,5 +154,31 @@ public class CassandraStoreTest extends StoreTest<CassandraStore> {
     } catch (Exception exception) {
       assertTrue(exception.getCause() instanceof IndexOutOfBoundsException);
     }
+  }
+
+  @Test
+  public void getLabelMetaPresent() throws Exception {
+    final String name = "meta_test";
+    final LabelId nameId = store.createLabel(name, METRIC).get();
+
+    final Row row = store.getOptionalMeta(nameId, METRIC).get().get();
+
+    final LabelMeta labelMeta = LabelMeta.create(nameId, METRIC, name, "Description",
+        row.getDate("creation_time").getTime());
+    store.updateMeta(labelMeta);
+
+    final LabelMeta meta = store.getMeta(nameId, METRIC).get().get();
+    Assert.assertEquals(METRIC, meta.type());
+    assertEquals(name, meta.name());
+    Assert.assertEquals(nameId, meta.identifier());
+  }
+
+  @Test
+  public void getLabelMetaMetaNotPresent() throws Exception {
+    final String name = "meta_test";
+    final LabelId nameId = store.createLabel(name, METRIC).get();
+
+    final Optional<LabelMeta> optional = store.getMeta(nameId, METRIC).get();
+    assertFalse(optional.isPresent());
   }
 }

--- a/core/src/test/java/se/tre/freki/core/MetaClientLabelMetaTest.java
+++ b/core/src/test/java/se/tre/freki/core/MetaClientLabelMetaTest.java
@@ -40,9 +40,11 @@ public class MetaClientLabelMetaTest {
   @Mock private SearchPlugin searchPlugin;
 
   private LabelId sysCpu0;
+  private LabelId sysCpu1;
   private LabelId miss;
 
-  private String name = "sys.cpu.0";
+  private String labelOneName = "sys.cpu.0";
+  private String labelTwoName = "sys.cpu.1";
 
   @Rule
   public final Timeout timeout = Timeout.millis(TestUtil.TIMEOUT);
@@ -52,9 +54,10 @@ public class MetaClientLabelMetaTest {
     DaggerTestComponent.create().inject(this);
     MockitoAnnotations.initMocks(this);
 
-    sysCpu0 = store.createLabel(name, LabelType.METRIC).get();
+    sysCpu0 = store.createLabel(labelOneName, LabelType.METRIC).get();
+    sysCpu1 = store.createLabel(labelTwoName, LabelType.METRIC).get();
 
-    LabelMeta labelMeta = LabelMeta.create(sysCpu0, LabelType.METRIC, name, "Description",
+    LabelMeta labelMeta = LabelMeta.create(sysCpu0, LabelType.METRIC, labelOneName, "Description",
         1328140801);
     miss = MemoryLabelId.randomLabelId();
 
@@ -62,11 +65,17 @@ public class MetaClientLabelMetaTest {
   }
 
   @Test
-  public void getLabelMeta() throws Exception {
+  public void getLabelMetaPresent() throws Exception {
     final LabelMeta meta = metaClient.getLabelMeta(LabelType.METRIC, sysCpu0).get().get();
     Assert.assertEquals(LabelType.METRIC, meta.type());
-    assertEquals(name, meta.name());
+    assertEquals(labelOneName, meta.name());
     Assert.assertEquals(sysCpu0, meta.identifier());
+  }
+
+  @Test
+  public void getLabelMetaMetaNotSet() throws Exception {
+    final Optional<LabelMeta> optional = metaClient.getLabelMeta(LabelType.METRIC, sysCpu1).get();
+    assertFalse(optional.isPresent());
   }
 
   @Test

--- a/core/src/test/java/se/tre/freki/storage/StoreTest.java
+++ b/core/src/test/java/se/tre/freki/storage/StoreTest.java
@@ -15,6 +15,7 @@ import se.tre.freki.labels.LabelId;
 import se.tre.freki.labels.LabelType;
 import se.tre.freki.labels.StaticTimeSeriesId;
 import se.tre.freki.labels.TimeSeriesId;
+import se.tre.freki.meta.LabelMeta;
 import se.tre.freki.query.DataPoint;
 import se.tre.freki.query.TimeSeriesQuery;
 import se.tre.freki.query.predicate.TimeSeriesQueryPredicate;
@@ -145,5 +146,12 @@ public abstract class StoreTest<K extends Store> {
     for (int dataPointIdx = 0; dataPointIdx < 10; dataPointIdx++) {
       assertEquals(value, ((DataPoint.LongDataPoint) iterator.next()).value());
     }
+  }
+  
+  @Test
+  public void testGetLabelMetaMissingId() throws Exception {
+    final LabelId miss = missingLabelId();
+    Optional<LabelMeta> meta = store.getMeta(miss, METRIC).get();
+    assertFalse(meta.isPresent());
   }
 }


### PR DESCRIPTION
Added tests to check if meta was not set but label created. As well as tests in the CassandraStore to make sure cassandra results behave according to how we want them to work.

See #105