### PR TITLE
BaseTimeGenerator will not always terminate in time

### DIFF
--- a/cassandra/src/main/java/se/tre/freki/storage/cassandra/BaseTimes.java
+++ b/cassandra/src/main/java/se/tre/freki/storage/cassandra/BaseTimes.java
@@ -39,13 +39,13 @@ final class BaseTimes {
     private long current;
 
     public BaseTimeGenerator(final long start, final long end) {
-      this.end = end;
+      this.end = baseTimeFor(end + BASE_TIME_PERIOD);
       this.current = start;
     }
 
     @Override
     public boolean hasNext() {
-      return current < end + BASE_TIME_PERIOD - 1;
+      return current < end;
     }
 
     @Override

--- a/cassandra/src/test/java/se/tre/freki/storage/cassandra/BaseTimesTest.java
+++ b/cassandra/src/test/java/se/tre/freki/storage/cassandra/BaseTimesTest.java
@@ -2,6 +2,7 @@ package se.tre.freki.storage.cassandra;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static se.tre.freki.storage.cassandra.BaseTimes.BASE_TIME_PERIOD;
 import static se.tre.freki.storage.cassandra.BaseTimes.baseTimesBetween;
 
 import org.junit.Test;
@@ -29,6 +30,16 @@ public class BaseTimesTest {
   public void testBaseTimesBetweenInstantBaseTime() throws Exception {
     final long baseTime = 1434542400000L;
     final PrimitiveIterator.OfLong baseTimes = baseTimesBetween(baseTime, baseTime);
+    assertEquals(baseTime, baseTimes.nextLong());
+    assertFalse(baseTimes.hasNext());
+  }
+
+  @Test
+  public void testBaseTimesBetweenEndIsBaseTime() throws Exception {
+    final long baseTime = 1434542400000L;
+    final PrimitiveIterator.OfLong baseTimes = baseTimesBetween(
+        baseTime - BASE_TIME_PERIOD + 1, baseTime + BASE_TIME_PERIOD - 1);
+    assertEquals(baseTime - BASE_TIME_PERIOD, baseTimes.nextLong());
     assertEquals(baseTime, baseTimes.nextLong());
     assertFalse(baseTimes.hasNext());
   }


### PR DESCRIPTION
We do not normalize the end time in `BaseTimeGenerator` and this causes it to generate one partition key too much.