### PR TITLE
Don't crash on already existing name during label allocation

### DIFF
--- a/label-manager/create-label/src/main/java/se/tre/freki/labelmanager/CreateLabel.java
+++ b/label-manager/create-label/src/main/java/se/tre/freki/labelmanager/CreateLabel.java
@@ -85,7 +85,7 @@ public final class CreateLabel {
         assignments.add(createLabel.createLabel(name, type));
       }
 
-      Futures.allAsList(assignments).get();
+      Futures.successfulAsList(assignments).get();
       store.close();
     } catch (IllegalArgumentException | OptionException e) {
       application.printError(e.getMessage());


### PR DESCRIPTION
We already log the failure elsewhere in `CreateLabel` so there is no need to crash it.